### PR TITLE
Add CMake Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(RADULS)
+
+IF(CMAKE_BUILD_TYPE MATCHES Release)
+  message(STATUS "build type is release")
+  string(REPLACE "-O2" "" CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
+  string(REPLACE "-O3" "" CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
+  string(REPLACE "-O0" "" CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
+  string(APPEND CMAKE_CXX_FLAGS_RELEASE " -O1 -march=native")
+endif()
+
+### RADULS
+add_library(raduls STATIC Raduls/sorting_network.cpp)
+target_include_directories(raduls INTERFACE Raduls)

--- a/Raduls/defs.h
+++ b/Raduls/defs.h
@@ -18,4 +18,5 @@ namespace raduls
 	using uint32 = uint32_t;
 	using int64 = int64_t;
 	using uint64 = uint64_t;
+	constexpr uint32 ALIGNMENT = 0x100;
 }

--- a/Raduls/defs.h
+++ b/Raduls/defs.h
@@ -18,5 +18,4 @@ namespace raduls
 	using uint32 = uint32_t;
 	using int64 = int64_t;
 	using uint64 = uint64_t;
-	constexpr uint32 ALIGNMENT = 0x100;
 }

--- a/Raduls/raduls.h
+++ b/Raduls/raduls.h
@@ -21,7 +21,6 @@ namespace raduls
 	//config
 	const uint32_t MAX_REC_SIZE_IN_BYTES = 32;
 
-	constexpr uint32 ALIGNMENT = 0x100;
 	constexpr int32 BUFFER_WIDTHS[] = { -1, 32, 16, 16, 8, 8, 4, 8, 4 };
 	const uint64 small_sort_thresholds[] = { 384, 384, 384, 384, 384, 384, 384, 384, 384, 384, 384, 384, 384, 384, 384, 384 };	
 	const uint64 wide_small_sort_thresholds[] = { 64, 48, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32 };

--- a/Raduls/raduls.h
+++ b/Raduls/raduls.h
@@ -21,6 +21,7 @@ namespace raduls
 	//config
 	const uint32_t MAX_REC_SIZE_IN_BYTES = 32;
 
+	constexpr uint32 ALIGNMENT = 0x100;
 	constexpr int32 BUFFER_WIDTHS[] = { -1, 32, 16, 16, 8, 8, 4, 8, 4 };
 	const uint64 small_sort_thresholds[] = { 384, 384, 384, 384, 384, 384, 384, 384, 384, 384, 384, 384, 384, 384, 384, 384 };	
 	const uint64 wide_small_sort_thresholds[] = { 64, 48, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32 };


### PR DESCRIPTION
Adds a CMakeLists.txt file for CMake support. In your own CMakeLists.txt you only include the this repository and link to the library 'raduls'.